### PR TITLE
Refinement for 1751, 3669, and 3665

### DIFF
--- a/data/raw/f_1751_hanhu.py
+++ b/data/raw/f_1751_hanhu.py
@@ -27,8 +27,6 @@ def f_1752(numbers):
         >>> result = f_1752([1, 2, 2, 3, 3, 3])
         >>> 'mode' in result and result['mode'] == 3 and 'entropy' in result
         True
-        >>> 'mode' in f_1752([1, 1, 2])
-        True
     """
     if len(numbers) == 0:
         raise ValueError

--- a/data/raw/f_1751_hanhu.py
+++ b/data/raw/f_1751_hanhu.py
@@ -1,83 +1,88 @@
 import numpy as np
 from scipy.stats import mode
+from scipy.stats import entropy
 
-def f_1752(my_dict):
+
+def f_1752(numbers):
     """
-    Updates a given dictionary by adding the mode (most frequent element) of a numpy array found under the 'array' key.
-    The function calculates the mode of the numpy array and adds it to the dictionary with the key 'mode'.
-    The original dictionary is modified in place.
+    Creates and returns a dictionary with the mode and entropy of a numpy array constructed from a given list.
+    The function first converts the list into a numpy array, then calculates the mode and the entropy of this array,
+    and finally adds them to a new dictionary with the keys 'mode' and 'entropy'.
 
     Parameters:
-        my_dict (dict): A dictionary that must contain the key 'array' with a non-empty numpy array as its value.
+        numbers (list): A non-empty list of numbers from which a numpy array is created to calculate mode and entropy.
 
     Returns:
-        dict: The original dictionary with the added key 'mode'. The value is the mode of the array.
+        dict: A dictionary containing the 'mode' and 'entropy' of the array with their respective calculated values.
 
-    Note:
-        - The function assumes that the 'array' key exists in the dictionary and it is non-empty.
-        - If 'array' is not present or is empty, a runtime error will occur.
-        - It assumes the array is not empty
+    Raises:
+        ValueError if the input list `numbers` is empty
 
     Requirements:
-    - numpy
-    - scipy.stats.mode
+        - numpy
+        - scipy.stats.mode
+        - scipy.stats.entropy
 
     Examples:
-    >>> example_dict = {'array': np.array([1, 2, 2, 3, 3, 3])}
-    >>> result = f_1752(example_dict)
-    >>> 'mode' in result and result['mode'] == 3
-    True
-    >>> 'array' in f_1752({'array': np.array([1, 1, 2])})
-    True
+        >>> result = f_1752([1, 2, 2, 3, 3, 3])
+        >>> 'mode' in result and result['mode'] == 3 and 'entropy' in result
+        True
+        >>> 'mode' in f_1752([1, 1, 2])
+        True
     """
+    if len(numbers) == 0:
+        raise ValueError
+    my_dict = {'array': np.array(numbers)}
     mode_value = mode(my_dict['array']).mode[0]
+    ent = entropy(my_dict['array'], base=2)
     my_dict['mode'] = mode_value
+    my_dict['entropy'] = ent
     return my_dict
+
 
 import unittest
 import numpy as np
+from scipy.stats import mode, entropy
 
 class TestCases(unittest.TestCase):
     def test_return_type(self):
         """Test that the function returns a dictionary."""
-        result = f_1752({'array': np.array([1, 2, 3])})
+        result = f_1752([1, 2, 3])
         self.assertIsInstance(result, dict)
 
     def test_mode_calculation(self):
         """Test that the mode is correctly calculated."""
-        result = f_1752({'array': np.array([1, 2, 2, 3])})
+        result = f_1752([1, 2, 2, 3])
         self.assertEqual(result['mode'], 2)
+
+    def test_entropy_calculation(self):
+        """Test that the entropy is correctly calculated."""
+        test_array = np.array([1, 2, 2, 3])
+        expected_entropy = entropy(test_array, base=2)
+        result = f_1752([1, 2, 2, 3])
+        self.assertAlmostEqual(result['entropy'], expected_entropy)
 
     def test_multiple_modes(self):
         """Test that in case of multiple modes, the first mode encountered is returned."""
-        result = f_1752({'array': np.array([1, 1, 2, 2, 3])})
+        result = f_1752([1, 1, 2, 2, 3])
         self.assertEqual(result['mode'], 1)
 
-    def test_preservation_of_original_dict(self):
-        """Test that original keys in the dictionary are preserved after adding the mode."""
-        original_dict = {'array': np.array([1, 1, 2, 2, 3]), 'other_key': 'value'}
-        result = f_1752(original_dict)
-        self.assertIn('other_key', result)
-        self.assertEqual(result['other_key'], 'value')
+    def test_dictionary_keys(self):
+        """Test that the returned dictionary contains the correct keys."""
+        result = f_1752([1, 1, 2, 2, 3])
+        self.assertIn('mode', result)
+        self.assertIn('entropy', result)
 
-    def test_dictionary_length_update(self):
-        """Test that the dictionary length is correctly updated when a new 'mode' key is added."""
-        original_dict = {'array': np.array([1, 2, 3]), 'other_key': 'value'}
-        expected_length = len(original_dict) + 1
-        result = f_1752(original_dict)
-        self.assertEqual(len(result), expected_length)
+    def test_empty_input_list(self):
+        """Test that the function raises a ValueError when the input list is empty."""
+        with self.assertRaises(ValueError):
+            f_1752([])
 
-    def test_missing_array_key(self):
-        """Test that the function raises a KeyError when the 'array' key is missing."""
-        with self.assertRaises(KeyError):
-            f_1752({})
-
-    def test_single_element_array(self):
-        """Test that the function correctly handles an array with a single element."""
-        result = f_1752({'array': np.array([42])})
+    def test_single_element_list(self):
+        """Test that the function correctly handles a list with a single element."""
+        result = f_1752([42])
         self.assertEqual(result['mode'], 42)
-
-
+        self.assertEqual(result['entropy'], 0.0)
 
 def run_tests():
     """Run all tests for this function."""

--- a/data/raw/f_1751_hanhu.py
+++ b/data/raw/f_1751_hanhu.py
@@ -7,7 +7,7 @@ def f_1752(numbers):
     """
     Creates and returns a dictionary with the mode and entropy of a numpy array constructed from a given list.
     The function first converts the list into a numpy array, then calculates the mode and the entropy of this array,
-    and finally adds them to a new dictionary with the keys 'mode' and 'entropy'.
+    and finally adds them to the initial dictionary with the keys 'mode' and 'entropy'.
 
     Parameters:
         numbers (list): A non-empty list of numbers from which a numpy array is created to calculate mode and entropy.


### PR DESCRIPTION
Initially, 1751, 3669, and 3665 are considered by the script in parse.py as using less than 2 libraries.

- This PR add more libraries in 1751. 
- I found that 3669 and 3665 already used 2 libraries. Please kindly clarify. I will update this PR accordingly if these two instances need refinement.

This is 3665
```
import json
from datetime import datetime
from decimal import Decimal

def f_3667(my_obj):
    """
    Serializes an object to a JSON string, adding support for datetime and Decimal data types.
    
    Handle complex data types not natively supported by the json module's default encoder. The `My_class` parameter is reserved for future use and does 
    not affect the current implementation.
    
    Parameters:
    - my_obj (object): The object to serialize, can include complex types such as datetime and Decimal.
    
    Returns:
    - str: A JSON-formatted string representing `my_obj`, with datetime and Decimal objects properly serialized.
        
    Requirements:
    - json
    - datetime.datetime
    - decimal.Decimal
    
    Examples:
    Serialize a dictionary containing datetime and Decimal:
    >>> result = f_3667({'time': datetime(2023, 4, 1, 12, 0), 'amount': Decimal('10.99')})
    >>> '2023-04-01T12:00:00' in result and '10.99' in result
    True

    Serialize a simple dictionary:
    >>> f_3667({'name': 'Alice', 'age': 30})
    '{"name": "Alice", "age": 30}'
    """
    class DateTimeEncoder(json.JSONEncoder):
        def default(self, obj):
            if isinstance(obj, datetime):
                return obj.isoformat()
            if isinstance(obj, Decimal):
                return str(obj)
            return json.JSONEncoder.default(self, obj)
    return json.dumps(my_obj, cls=DateTimeEncoder)
```

This is 3669
```
import json
from enum import Enum

class Color(Enum):
    RED = 1
    GREEN = 2
    BLUE = 3


def f_3671(my_obj):
    """
    Serializes an object into a JSON string with support for complex data types like Enum.
    The function uses a custom JSONEncoder to handle Enum types by converting them to their names or values.

    Parameters:
    my_obj (object): The object to be serialized. Can be a dictionary, list, etc.

    Returns:
    str: The serialized JSON string of the object.

    Requirements:
    - json
    - enum

    Examples:
    Serialize a dictionary containing Enum.
    >>> result = f_3671({'color': Color.RED})
    >>> 'RED' in result
    True

    Serialize a simple dictionary.
    >>> f_3671({'name': 'Alice', 'age': 30})
    '{"name": "Alice", "age": 30}'
    """
    class EnumEncoder(json.JSONEncoder):
        def default(self, obj):
            if isinstance(obj, Enum):
                return obj.name  # or obj.value, depending on the requirement
            return json.JSONEncoder.default(self, obj)
    return json.dumps(my_obj, cls=EnumEncoder)
```
